### PR TITLE
DEVO-1053 - Update action to use Node 24 runtime +semver:major

### DIFF
--- a/.github/workflows/build-and-review-pr.yml
+++ b/.github/workflows/build-and-review-pr.yml
@@ -46,7 +46,7 @@ jobs:
       action-name: ${{ github.repository }}
       default-branch: main
       readme-name: 'README.md'
-      node-version: 20
+      node-version: 24
 
       # The id of the contribution guidelines section of the README.md
       readme-contribution-id: '#contributing'

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ jobs:
         if: always()
         id: process-cypress
         # You may also reference just the major or major.minor version
-        uses: im-open/process-cypress-test-results@v3.0.2
+        uses: im-open/process-cypress-test-results@v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           results-file: '${{ env.APP_DIR }}/raw-results.json' # Name set up in npm script `cypressreport`

--- a/action.yml
+++ b/action.yml
@@ -61,5 +61,5 @@ outputs:
     description: 'The ID of the PR comment that was created.  This is only set if `create-pr-comment` is `true` and a PR was created successfully.'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
# Summary of PR changes

Updated the action to use Node 24 runtime instead of Node 20. This is a major breaking change as Node 20 will be deprecated and workflows using this action will need to be aware of the runtime upgrade.

## Changes Made:
- Updated `action.yml` to use `node24` runtime (previously `node20`)
- Updated `.github/workflows/build-and-review-pr.yml` to use `node-version: 24` (previously `20`)
- Recompiled the action using `npm run build`

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
  - ✅ Commit message includes `+semver:major` keyword
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
- ✅ Action has been manually recompiled
- ℹ️ README.md will be automatically updated by the workflow upon merge